### PR TITLE
Allow to list network volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Networks Volumes are now listed in the `Innmind\Server\Status\Server\Disk::volumes()` method
+
 ## 4.1.0 - 2023-09-23
 
 ### Added

--- a/src/Server/Disk/UnixDisk.php
+++ b/src/Server/Disk/UnixDisk.php
@@ -45,7 +45,7 @@ final class UnixDisk implements Disk
             ->processes
             ->execute(
                 Command::foreground('df')
-                    ->withShortOption('lh'),
+                    ->withShortOption('h'),
             )
             ->wait()
             ->maybe()


### PR DESCRIPTION
## Description

Actually, the `Volume` abstraction execute the Unix command `df -lh` to list metrics about the volumes used on the current machine. 

The problem is [-l, --local flag limit listing to local file systems](https://linuxcommand.org/lc3_man_pages/df1.html) and prevent from displaying information about network volumes.

## Solution

Remove the flag.

