### PR TITLE
Fix deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Requires `innmind/immutable:~5.14`
+
 ## 4.1.1 - 2024-09-30
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "php": "~8.2",
-        "innmind/immutable": "~4.15|~5.0",
+        "innmind/immutable": "~5.14",
         "innmind/time-continuum": "~3.0",
         "innmind/url": "~4.0",
         "psr/log": "~3.0",


### PR DESCRIPTION
## Problem

Since `innmind/immutable` `5.14` the method `Sequence::indexOf()` is deprecated. Because of this the CI fails as this method is used in this project.

## Solution

- Requires `innmind/immutable:~5.14`
- Replace `Sequence::indexOf()` by `Sequence::zip()` to associate each column name to the corresponding value