### PR TITLE
Use types to make sure value objects are correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `Innmind\Server\Status\Exception\EmptyPathNotAllowed`
 - `Innmind\Server\Status\Exception\BytesCannotBeNegative`
 - `Innmind\Server\Status\Exception\EmptyCommandNotAllowed`
+- `Innmind\Server\Status\Exception\OutOfBoundsPercentage`
 
 ## 4.1.1 - 2024-09-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `Innmind\Server\Status\Exception\LowestPidPossibleIsOne`
 - `Innmind\Server\Status\Exception\EmptyUserNotAllowed`
 - `Innmind\Server\Status\Exception\LoadAverageCannotBeNegative`
+- `Innmind\Server\Status\Exception\DomainException`
 
 ## 4.1.1 - 2024-09-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `Innmind\Server\Status\Exception\EmptyCommandNotAllowed`
 - `Innmind\Server\Status\Exception\OutOfBoundsPercentage`
 - `Innmind\Server\Status\Exception\LowestPidPossibleIsOne`
+- `Innmind\Server\Status\Exception\EmptyUserNotAllowed`
 
 ## 4.1.1 - 2024-09-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - `Innmind\Server\Status\Server::cpu()` now returns `Innmind\Immutable\Attempt<Innmind\Server\Status\Server\Cpu>`
 - `Innmind\Server\Status\Server::memory()` now returns `Innmind\Immutable\Attempt<Innmind\Server\Status\Server\Memory>`
 
+### Removed
+
+- `Innmind\Server\Status\Exception\EmptyPathNotAllowed`
+
 ## 4.1.1 - 2024-09-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Requires `innmind/immutable:~5.14`
 - `Innmind\Server\Status\Server::cpu()` now returns `Innmind\Immutable\Attempt<Innmind\Server\Status\Server\Cpu>`
 - `Innmind\Server\Status\Server::memory()` now returns `Innmind\Immutable\Attempt<Innmind\Server\Status\Server\Memory>`
+- `Innmind\Server\Status\Server::loadAverage()` now returns `Innmind\Immutable\Attempt<Innmind\Server\Status\Server\LoadAverage>`
 
 ### Removed
 
@@ -16,6 +17,7 @@
 - `Innmind\Server\Status\Exception\OutOfBoundsPercentage`
 - `Innmind\Server\Status\Exception\LowestPidPossibleIsOne`
 - `Innmind\Server\Status\Exception\EmptyUserNotAllowed`
+- `Innmind\Server\Status\Exception\LoadAverageCannotBeNegative`
 
 ## 4.1.1 - 2024-09-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - `Innmind\Server\Status\Exception\EmptyPathNotAllowed`
 - `Innmind\Server\Status\Exception\BytesCannotBeNegative`
+- `Innmind\Server\Status\Exception\EmptyCommandNotAllowed`
 
 ## 4.1.1 - 2024-09-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Removed
 
 - `Innmind\Server\Status\Exception\EmptyPathNotAllowed`
+- `Innmind\Server\Status\Exception\BytesCannotBeNegative`
 
 ## 4.1.1 - 2024-09-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `Innmind\Server\Status\Exception\BytesCannotBeNegative`
 - `Innmind\Server\Status\Exception\EmptyCommandNotAllowed`
 - `Innmind\Server\Status\Exception\OutOfBoundsPercentage`
+- `Innmind\Server\Status\Exception\LowestPidPossibleIsOne`
 
 ## 4.1.1 - 2024-09-30
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "innmind/time-continuum": "^4.1.1",
         "innmind/url": "~4.0",
         "psr/log": "~3.0",
-        "innmind/server-control": "~6.0"
+        "innmind/server-control": "~6.0",
+        "innmind/validation": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Exception/BytesCannotBeNegative.php
+++ b/src/Exception/BytesCannotBeNegative.php
@@ -1,8 +1,0 @@
-<?php
-declare(strict_types = 1);
-
-namespace Innmind\Server\Status\Exception;
-
-final class BytesCannotBeNegative extends DomainException
-{
-}

--- a/src/Exception/DomainException.php
+++ b/src/Exception/DomainException.php
@@ -1,8 +1,0 @@
-<?php
-declare(strict_types = 1);
-
-namespace Innmind\Server\Status\Exception;
-
-class DomainException extends \DomainException implements Exception
-{
-}

--- a/src/Exception/EmptyCommandNotAllowed.php
+++ b/src/Exception/EmptyCommandNotAllowed.php
@@ -1,8 +1,0 @@
-<?php
-declare(strict_types = 1);
-
-namespace Innmind\Server\Status\Exception;
-
-final class EmptyCommandNotAllowed extends DomainException
-{
-}

--- a/src/Exception/EmptyPathNotAllowed.php
+++ b/src/Exception/EmptyPathNotAllowed.php
@@ -1,8 +1,0 @@
-<?php
-declare(strict_types = 1);
-
-namespace Innmind\Server\Status\Exception;
-
-final class EmptyPathNotAllowed extends DomainException
-{
-}

--- a/src/Exception/EmptyUserNotAllowed.php
+++ b/src/Exception/EmptyUserNotAllowed.php
@@ -1,8 +1,0 @@
-<?php
-declare(strict_types = 1);
-
-namespace Innmind\Server\Status\Exception;
-
-final class EmptyUserNotAllowed extends DomainException
-{
-}

--- a/src/Exception/LoadAverageCannotBeNegative.php
+++ b/src/Exception/LoadAverageCannotBeNegative.php
@@ -1,8 +1,0 @@
-<?php
-declare(strict_types = 1);
-
-namespace Innmind\Server\Status\Exception;
-
-final class LoadAverageCannotBeNegative extends DomainException
-{
-}

--- a/src/Exception/LowestPidPossibleIsOne.php
+++ b/src/Exception/LowestPidPossibleIsOne.php
@@ -1,8 +1,0 @@
-<?php
-declare(strict_types = 1);
-
-namespace Innmind\Server\Status\Exception;
-
-final class LowestPidPossibleIsOne extends DomainException
-{
-}

--- a/src/Exception/OutOfBoundsPercentage.php
+++ b/src/Exception/OutOfBoundsPercentage.php
@@ -1,8 +1,0 @@
-<?php
-declare(strict_types = 1);
-
-namespace Innmind\Server\Status\Exception;
-
-final class OutOfBoundsPercentage extends DomainException
-{
-}

--- a/src/Facade/Cpu/LinuxFacade.php
+++ b/src/Facade/Cpu/LinuxFacade.php
@@ -12,6 +12,7 @@ use Innmind\Server\Control\Server\{
     Processes,
     Command,
 };
+use Innmind\Validation\Is;
 use Innmind\Immutable\{
     Str,
     Attempt,
@@ -85,6 +86,7 @@ final class LinuxFacade
                     ->toString(),
             )
             ->map(static fn($cores) => (int) $cores)
+            ->keep(Is::int()->positive()->asPredicate())
             ->match(
                 static fn($cores) => $cores,
                 static fn() => 1,
@@ -99,7 +101,7 @@ final class LinuxFacade
                 new Percentage($user),
                 new Percentage($sys),
                 new Percentage($idle),
-                new Cores($cores),
+                Cores::of($cores),
             ))
             ->match(
                 Attempt::result(...),

--- a/src/Facade/Cpu/LinuxFacade.php
+++ b/src/Facade/Cpu/LinuxFacade.php
@@ -92,15 +92,21 @@ final class LinuxFacade
                 static fn() => 1,
             );
 
-        $user = $percentages->get('user');
-        $sys = $percentages->get('sys');
-        $idle = $percentages->get('idle');
+        $user = $percentages
+            ->get('user')
+            ->flatMap(Percentage::maybe(...));
+        $sys = $percentages
+            ->get('sys')
+            ->flatMap(Percentage::maybe(...));
+        $idle = $percentages
+            ->get('idle')
+            ->flatMap(Percentage::maybe(...));
 
         return Maybe::all($user, $sys, $idle)
-            ->map(static fn(float $user, float $sys, float $idle) => new Cpu(
-                new Percentage($user),
-                new Percentage($sys),
-                new Percentage($idle),
+            ->map(static fn(Percentage $user, Percentage $sys, Percentage $idle) => new Cpu(
+                $user,
+                $sys,
+                $idle,
                 Cores::of($cores),
             ))
             ->match(

--- a/src/Facade/Cpu/OSXFacade.php
+++ b/src/Facade/Cpu/OSXFacade.php
@@ -102,15 +102,21 @@ final class OSXFacade
                 static fn($cores) => $cores,
                 static fn() => 1,
             );
-        $user = $percentages->get('user');
-        $sys = $percentages->get('sys');
-        $idle = $percentages->get('idle');
+        $user = $percentages
+            ->get('user')
+            ->flatMap(Percentage::maybe(...));
+        $sys = $percentages
+            ->get('sys')
+            ->flatMap(Percentage::maybe(...));
+        $idle = $percentages
+            ->get('idle')
+            ->flatMap(Percentage::maybe(...));
 
         return Maybe::all($user, $sys, $idle)
-            ->map(static fn(float $user, float $sys, float $idle) => new Cpu(
-                new Percentage($user),
-                new Percentage($sys),
-                new Percentage($idle),
+            ->map(static fn(Percentage $user, Percentage $sys, Percentage $idle) => new Cpu(
+                $user,
+                $sys,
+                $idle,
                 Cores::of($cores),
             ))
             ->match(

--- a/src/Facade/Cpu/OSXFacade.php
+++ b/src/Facade/Cpu/OSXFacade.php
@@ -98,10 +98,8 @@ final class OSXFacade
             ->map(static fn($cores) => $cores->toString())
             ->map(static fn($cores) => (int) $cores)
             ->keep(Is::int()->positive()->asPredicate())
-            ->match(
-                static fn($cores) => $cores,
-                static fn() => 1,
-            );
+            ->otherwise(static fn() => Maybe::just(1))
+            ->map(Cores::of(...));
         $user = $percentages
             ->get('user')
             ->flatMap(Percentage::maybe(...));
@@ -112,13 +110,8 @@ final class OSXFacade
             ->get('idle')
             ->flatMap(Percentage::maybe(...));
 
-        return Maybe::all($user, $sys, $idle)
-            ->map(static fn(Percentage $user, Percentage $sys, Percentage $idle) => new Cpu(
-                $user,
-                $sys,
-                $idle,
-                Cores::of($cores),
-            ))
+        return Maybe::all($user, $sys, $idle, $cores)
+            ->map(Cpu::of(...))
             ->match(
                 Attempt::result(...),
                 static fn() => Attempt::error(new \RuntimeException('Failed to parse CPU usage')),

--- a/src/Facade/LoadAverage/PhpFacade.php
+++ b/src/Facade/LoadAverage/PhpFacade.php
@@ -4,17 +4,24 @@ declare(strict_types = 1);
 namespace Innmind\Server\Status\Facade\LoadAverage;
 
 use Innmind\Server\Status\Server\LoadAverage;
+use Innmind\Immutable\Attempt;
 
 /**
  * @internal
  */
 final class PhpFacade
 {
-    public function __invoke(): LoadAverage
+    /**
+     * @return Attempt<LoadAverage>
+     */
+    public function __invoke(): Attempt
     {
-        /** @var array{0: int, 1: int, 2: int} */
+        /** @var array{0: float, 1: float, 2: float} */
         $load = \sys_getloadavg();
 
-        return new LoadAverage($load[0], $load[1], $load[2]);
+        return LoadAverage::maybe($load[0], $load[1], $load[2])->match(
+            Attempt::result(...),
+            static fn() => Attempt::error(new \RuntimeException('Failed to load load average')),
+        );
     }
 }

--- a/src/Facade/Memory/LinuxFacade.php
+++ b/src/Facade/Memory/LinuxFacade.php
@@ -99,7 +99,6 @@ final class LinuxFacade
                     ])
                     ->toSequence(),
             );
-        dump($amounts);
         $amounts = Map::of(...$amounts->toList())
             ->map(static fn($_, $value) => Bytes::of(
                 $value->toInt() * 1024, // 1024 represents a kilobyte

--- a/src/Facade/Memory/LinuxFacade.php
+++ b/src/Facade/Memory/LinuxFacade.php
@@ -96,6 +96,7 @@ final class LinuxFacade
                     ->map(static fn(string $key, Bytes $value) => [$key, $value])
                     ->toSequence(),
             );
+        dump($amounts);
         $amounts = Map::of(...$amounts->toList())
             ->map(static fn($_, $value) => Bytes::of(
                 $value->toInt() * 1024, // 1024 represents a kilobyte

--- a/src/Facade/Memory/LinuxFacade.php
+++ b/src/Facade/Memory/LinuxFacade.php
@@ -11,6 +11,7 @@ use Innmind\Server\Control\Server\{
     Processes,
     Command,
 };
+use Innmind\Validation\Is;
 use Innmind\Immutable\{
     Str,
     Map,
@@ -67,44 +68,53 @@ final class LinuxFacade
      */
     private function parse(Str $output): Attempt
     {
-        /** @var Map<string, int> */
         $amounts = $output
             ->trim()
             ->split("\n")
             ->filter(static fn(Str $line) => $line->matches(
                 '~^('.\implode('|', \array_keys(self::$entries)).'):~',
             ))
-            ->reduce(
-                Map::of(),
-                static function(Map $map, Str $line): Map {
-                    $elements = $line
-                        ->capture('~^(?P<key>[a-zA-Z]+): +(?P<value>\d+) kB$~')
-                        ->map(static fn($_, $part) => $part->toString());
-
-                    return Maybe::all($elements->get('key'), $elements->get('value'))
-                        ->map(static fn(string $key, string $value) => [$key, (int) $value])
-                        ->match(
-                            static fn($pair) => ($map)(
-                                self::$entries[$pair[0]],
-                                $pair[1] * 1024, // 1024 represents a kilobyte
-                            ),
-                            static fn() => $map,
-                        );
-                },
+            ->map(
+                static fn($line) => $line
+                    ->capture('~^(?P<key>[a-zA-Z]+): +(?P<value>\d+) kB$~')
+                    ->map(static fn($_, $part) => $part->toString()),
+            )
+            ->flatMap(
+                static fn($elements) => Maybe::all(
+                    $elements->get('key'),
+                    $elements
+                        ->get('value')
+                        ->map(static fn($value) => $value.'K')
+                        ->flatMap(Bytes::maybe(...)),
+                )
+                    ->map(static fn(string $key, Bytes $value) => [$key, $value])
+                    ->toSequence(),
             );
+        $amounts = Map::of(...$amounts->toList())
+            ->map(static fn($_, $value) => Bytes::of(
+                $value->toInt() * 1024, // 1024 represents a kilobyte
+            ));
         $total = $amounts->get('total');
         $free = $amounts->get('free');
         $active = $amounts->get('active');
         $swap = $amounts->get('swap');
-        $used = Maybe::all($total, $free)->map(static fn(int $total, int $free) => $total - $free);
+        $used = Maybe::all($total, $free)
+            ->map(static fn(Bytes $total, Bytes $free) => $total->toInt() - $free->toInt())
+            ->keep(
+                Is::int()
+                    ->positive()
+                    ->or(Is::value(0))
+                    ->asPredicate(),
+            )
+            ->map(Bytes::of(...));
 
         return Maybe::all($total, $active, $free, $swap, $used)
-            ->map(static fn(int $total, int $active, int $free, int $swap, int $used) => new Memory(
-                new Bytes($total),
-                new Bytes($active),
-                new Bytes($free),
-                new Bytes($swap),
-                new Bytes($used),
+            ->map(static fn(Bytes $total, Bytes $active, Bytes $free, Bytes $swap, Bytes $used) => new Memory(
+                $total,
+                $active,
+                $free,
+                $swap,
+                $used,
             ))
             ->match(
                 Attempt::result(...),

--- a/src/Facade/Memory/LinuxFacade.php
+++ b/src/Facade/Memory/LinuxFacade.php
@@ -109,13 +109,7 @@ final class LinuxFacade
             ->map(Bytes::of(...));
 
         return Maybe::all($total, $active, $free, $swap, $used)
-            ->map(static fn(Bytes $total, Bytes $active, Bytes $free, Bytes $swap, Bytes $used) => new Memory(
-                $total,
-                $active,
-                $free,
-                $swap,
-                $used,
-            ))
+            ->map(Memory::of(...))
             ->match(
                 Attempt::result(...),
                 static fn() => Attempt::error(new \RuntimeException('Failed to parse memory usage')),

--- a/src/Facade/Memory/LinuxFacade.php
+++ b/src/Facade/Memory/LinuxFacade.php
@@ -93,7 +93,10 @@ final class LinuxFacade
                         )
                         ->map(Bytes::of(...)),
                 )
-                    ->map(static fn(string $key, Bytes $value) => [$key, $value])
+                    ->map(static fn(string $key, Bytes $value) => [
+                        self::$entries[$key],
+                        $value,
+                    ])
                     ->toSequence(),
             );
         dump($amounts);

--- a/src/Facade/Memory/LinuxFacade.php
+++ b/src/Facade/Memory/LinuxFacade.php
@@ -84,8 +84,14 @@ final class LinuxFacade
                     $elements->get('key'),
                     $elements
                         ->get('value')
-                        ->map(static fn($value) => $value.'K')
-                        ->flatMap(Bytes::maybe(...)),
+                        ->map(static fn($value) => (int) $value)
+                        ->keep(
+                            Is::int()
+                                ->positive()
+                                ->or(Is::value(0))
+                                ->asPredicate(),
+                        )
+                        ->map(Bytes::of(...)),
                 )
                     ->map(static fn(string $key, Bytes $value) => [$key, $value])
                     ->toSequence(),

--- a/src/Facade/Memory/OSXFacade.php
+++ b/src/Facade/Memory/OSXFacade.php
@@ -95,13 +95,7 @@ final class OSXFacade
             ->map(Bytes::of(...));
 
         return Maybe::all($total, $active, $unused, $swap, $used)
-            ->map(static fn(Bytes $total, Bytes $active, Bytes $unused, Bytes $swap, Bytes $used) => new Memory(
-                $total,
-                $active,
-                $unused,
-                $swap,
-                $used,
-            ))
+            ->map(Memory::of(...))
             ->match(
                 Attempt::result(...),
                 static fn() => Attempt::error(new \RuntimeException('Failed to parse memory usage')),

--- a/src/Server.php
+++ b/src/Server.php
@@ -25,7 +25,11 @@ interface Server
      */
     public function memory(): Attempt;
     public function processes(): Processes;
-    public function loadAverage(): LoadAverage;
+
+    /**
+     * @return Attempt<LoadAverage>
+     */
+    public function loadAverage(): Attempt;
     public function disk(): Disk;
     public function tmp(): Path;
 }

--- a/src/Server/Cpu.php
+++ b/src/Server/Cpu.php
@@ -13,21 +13,21 @@ use Innmind\Server\Status\Server\Cpu\{
  */
 final class Cpu
 {
-    private Percentage $user;
-    private Percentage $system;
-    private Percentage $idle;
-    private Cores $cores;
+    private function __construct(
+        private Percentage $user,
+        private Percentage $system,
+        private Percentage $idle,
+        private Cores $cores,
+    ) {
+    }
 
-    public function __construct(
+    public static function of(
         Percentage $user,
         Percentage $system,
         Percentage $idle,
         Cores $cores,
-    ) {
-        $this->user = $user;
-        $this->system = $system;
-        $this->idle = $idle;
-        $this->cores = $cores;
+    ): self {
+        return new self($user, $system, $idle, $cores);
     }
 
     public function user(): Percentage

--- a/src/Server/Cpu.php
+++ b/src/Server/Cpu.php
@@ -21,6 +21,9 @@ final class Cpu
     ) {
     }
 
+    /**
+     * @psalm-pure
+     */
     public static function of(
         Percentage $user,
         Percentage $system,

--- a/src/Server/Cpu/Cores.php
+++ b/src/Server/Cpu/Cores.php
@@ -3,27 +3,30 @@ declare(strict_types = 1);
 
 namespace Innmind\Server\Status\Server\Cpu;
 
-use Innmind\Server\Status\Exception\DomainException;
-
 /**
  * @psalm-immutable
  */
 final class Cores
 {
-    private int $value;
-
     /**
-     * @throws DomainException
+     * @param int<1, max> $value
      */
-    public function __construct(int $value)
-    {
-        if ($value < 1) {
-            throw new DomainException((string) $value);
-        }
-
-        $this->value = $value;
+    private function __construct(
+        private int $value,
+    ) {
     }
 
+    /**
+     * @param int<1, max> $value
+     */
+    public static function of(int $value): self
+    {
+        return new self($value);
+    }
+
+    /**
+     * @return int<1, max>
+     */
     public function toInt(): int
     {
         return $this->value;

--- a/src/Server/Cpu/Cores.php
+++ b/src/Server/Cpu/Cores.php
@@ -17,6 +17,8 @@ final class Cores
     }
 
     /**
+     * @psalm-pure
+     *
      * @param int<1, max> $value
      */
     public static function of(int $value): self

--- a/src/Server/Cpu/Percentage.php
+++ b/src/Server/Cpu/Percentage.php
@@ -16,6 +16,8 @@ final class Percentage
     }
 
     /**
+     * @psalm-pure
+     *
      * @return Maybe<self>
      */
     public static function maybe(float $value): Maybe

--- a/src/Server/Cpu/Percentage.php
+++ b/src/Server/Cpu/Percentage.php
@@ -3,25 +3,29 @@ declare(strict_types = 1);
 
 namespace Innmind\Server\Status\Server\Cpu;
 
-use Innmind\Server\Status\Exception\OutOfBoundsPercentage;
+use Innmind\Immutable\Maybe;
 
 /**
  * @psalm-immutable
  */
 final class Percentage
 {
-    private float $value;
+    private function __construct(
+        private float $value,
+    ) {
+    }
 
     /**
-     * @throws OutOfBoundsPercentage
+     * @return Maybe<self>
      */
-    public function __construct(float $value)
+    public static function maybe(float $value): Maybe
     {
         if ($value < 0) {
-            throw new OutOfBoundsPercentage((string) $value);
+            /** @var Maybe<self> */
+            return Maybe::nothing();
         }
 
-        $this->value = $value;
+        return Maybe::just(new self($value));
     }
 
     public function toFloat(): float

--- a/src/Server/Disk/UnixDisk.php
+++ b/src/Server/Disk/UnixDisk.php
@@ -118,13 +118,7 @@ final class UnixDisk implements Disk
                 ->flatMap(Usage::maybe(...));
 
             return Maybe::all($mountPoint, $size, $available, $used, $usage)
-                ->map(static fn(MountPoint $mountPoint, Bytes $size, Bytes $available, Bytes $used, Usage $usage) => new Volume(
-                    $mountPoint,
-                    $size,
-                    $available,
-                    $used,
-                    $usage,
-                ));
+                ->map(Volume::of(...));
         });
 
         return $volumes

--- a/src/Server/Disk/UnixDisk.php
+++ b/src/Server/Disk/UnixDisk.php
@@ -105,13 +105,13 @@ final class UnixDisk implements Disk
                 ->map(MountPoint::of(...));
             $size = $parts
                 ->get('size')
-                ->flatMap(static fn($size) => Bytes::of($size));
+                ->flatMap(Bytes::maybe(...));
             $available = $parts
                 ->get('available')
-                ->flatMap(static fn($available) => Bytes::of($available));
+                ->flatMap(Bytes::maybe(...));
             $used = $parts
                 ->get('used')
-                ->flatMap(static fn($used) => Bytes::of($used));
+                ->flatMap(Bytes::maybe(...));
             $usage = $parts
                 ->get('usage')
                 ->map(static fn($value) => (float) $value)

--- a/src/Server/Disk/UnixDisk.php
+++ b/src/Server/Disk/UnixDisk.php
@@ -112,15 +112,18 @@ final class UnixDisk implements Disk
             $used = $parts
                 ->get('used')
                 ->flatMap(static fn($used) => Bytes::of($used));
-            $usage = $parts->get('usage');
+            $usage = $parts
+                ->get('usage')
+                ->map(static fn($value) => (float) $value)
+                ->flatMap(Usage::maybe(...));
 
             return Maybe::all($mountPoint, $size, $available, $used, $usage)
-                ->map(static fn(MountPoint $mountPoint, Bytes $size, Bytes $available, Bytes $used, string $usage) => new Volume(
+                ->map(static fn(MountPoint $mountPoint, Bytes $size, Bytes $available, Bytes $used, Usage $usage) => new Volume(
                     $mountPoint,
                     $size,
                     $available,
                     $used,
-                    new Usage((float) $usage),
+                    $usage,
                 ));
         });
 

--- a/src/Server/Disk/Volume.php
+++ b/src/Server/Disk/Volume.php
@@ -11,24 +11,23 @@ use Innmind\Server\Status\Server\{
 
 final class Volume
 {
-    private MountPoint $mountPoint;
-    private Bytes $size;
-    private Bytes $available;
-    private Bytes $used;
-    private Usage $usage;
+    private function __construct(
+        private MountPoint $mountPoint,
+        private Bytes $size,
+        private Bytes $available,
+        private Bytes $used,
+        private Usage $usage,
+    ) {
+    }
 
-    public function __construct(
+    public static function of(
         MountPoint $mountPoint,
         Bytes $size,
         Bytes $available,
         Bytes $used,
         Usage $usage,
-    ) {
-        $this->mountPoint = $mountPoint;
-        $this->size = $size;
-        $this->available = $available;
-        $this->used = $used;
-        $this->usage = $usage;
+    ): self {
+        return new self($mountPoint, $size, $available, $used, $usage);
     }
 
     public function mountPoint(): MountPoint

--- a/src/Server/Disk/Volume.php
+++ b/src/Server/Disk/Volume.php
@@ -9,6 +9,9 @@ use Innmind\Server\Status\Server\{
     Memory\Bytes,
 };
 
+/**
+ * @psalm-immutable
+ */
 final class Volume
 {
     private function __construct(
@@ -20,6 +23,9 @@ final class Volume
     ) {
     }
 
+    /**
+     * @psalm-pure
+     */
     public static function of(
         MountPoint $mountPoint,
         Bytes $size,

--- a/src/Server/Disk/Volume/MountPoint.php
+++ b/src/Server/Disk/Volume/MountPoint.php
@@ -36,6 +36,9 @@ final class MountPoint
         return $this->value === $point;
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function toString(): string
     {
         return $this->value;

--- a/src/Server/Disk/Volume/MountPoint.php
+++ b/src/Server/Disk/Volume/MountPoint.php
@@ -3,6 +3,9 @@ declare(strict_types = 1);
 
 namespace Innmind\Server\Status\Server\Disk\Volume;
 
+/**
+ * @psalm-immutable
+ */
 final class MountPoint
 {
     /**
@@ -14,6 +17,8 @@ final class MountPoint
     }
 
     /**
+     * @psalm-pure
+     *
      * @param non-empty-string $value
      */
     public static function of(string $value): self

--- a/src/Server/Disk/Volume/MountPoint.php
+++ b/src/Server/Disk/Volume/MountPoint.php
@@ -3,22 +3,22 @@ declare(strict_types = 1);
 
 namespace Innmind\Server\Status\Server\Disk\Volume;
 
-use Innmind\Server\Status\Exception\EmptyPathNotAllowed;
-
 final class MountPoint
 {
-    private string $value;
+    /**
+     * @param non-empty-string $value
+     */
+    private function __construct(
+        private string $value,
+    ) {
+    }
 
     /**
-     * @throws EmptyPathNotAllowed
+     * @param non-empty-string $value
      */
-    public function __construct(string $value)
+    public static function of(string $value): self
     {
-        if ($value === '') {
-            throw new EmptyPathNotAllowed;
-        }
-
-        $this->value = $value;
+        return new self($value);
     }
 
     public function equals(self $point): bool

--- a/src/Server/Disk/Volume/Usage.php
+++ b/src/Server/Disk/Volume/Usage.php
@@ -3,22 +3,26 @@ declare(strict_types = 1);
 
 namespace Innmind\Server\Status\Server\Disk\Volume;
 
-use Innmind\Server\Status\Exception\OutOfBoundsPercentage;
+use Innmind\Immutable\Maybe;
 
 final class Usage
 {
-    private float $value;
+    private function __construct(
+        private float $value,
+    ) {
+    }
 
     /**
-     * @throws OutOfBoundsPercentage
+     * @return Maybe<self>
      */
-    public function __construct(float $value)
+    public static function maybe(float $value): Maybe
     {
         if ($value < 0 || $value > 100) {
-            throw new OutOfBoundsPercentage((string) $value);
+            /** @var Maybe<self> */
+            return Maybe::nothing();
         }
 
-        $this->value = $value;
+        return Maybe::just(new self($value));
     }
 
     public function toFloat(): float

--- a/src/Server/Disk/Volume/Usage.php
+++ b/src/Server/Disk/Volume/Usage.php
@@ -5,6 +5,9 @@ namespace Innmind\Server\Status\Server\Disk\Volume;
 
 use Innmind\Immutable\Maybe;
 
+/**
+ * @psalm-immutable
+ */
 final class Usage
 {
     private function __construct(
@@ -13,6 +16,8 @@ final class Usage
     }
 
     /**
+     * @psalm-pure
+     *
      * @return Maybe<self>
      */
     public static function maybe(float $value): Maybe

--- a/src/Server/LoadAverage.php
+++ b/src/Server/LoadAverage.php
@@ -18,6 +18,8 @@ final class LoadAverage
     }
 
     /**
+     * @psalm-pure
+     *
      * @return Maybe<self>
      */
     public static function maybe(

--- a/src/Server/LoadAverage.php
+++ b/src/Server/LoadAverage.php
@@ -3,34 +3,34 @@ declare(strict_types = 1);
 
 namespace Innmind\Server\Status\Server;
 
-use Innmind\Server\Status\Exception\LoadAverageCannotBeNegative;
+use Innmind\Immutable\Maybe;
 
 /**
  * @psalm-immutable
  */
 final class LoadAverage
 {
-    private float $lastMinute;
-    private float $lastFiveMinutes;
-    private float $lastFifteenMinutes;
+    private function __construct(
+        private float $lastMinute,
+        private float $lastFiveMinutes,
+        private float $lastFifteenMinutes,
+    ) {
+    }
 
     /**
-     * @throws LoadAverageCannotBeNegative
+     * @return Maybe<self>
      */
-    public function __construct(
+    public static function maybe(
         float $lastMinute,
         float $lastFiveMinutes,
         float $lastFifteenMinutes,
-    ) {
+    ): Maybe {
         if ($lastMinute < 0 || $lastFiveMinutes < 0 || $lastFifteenMinutes < 0) {
-            throw new LoadAverageCannotBeNegative(
-                (string) \min($lastMinute, $lastFiveMinutes, $lastFifteenMinutes),
-            );
+            /** @var Maybe<self> */
+            return Maybe::nothing();
         }
 
-        $this->lastMinute = $lastMinute;
-        $this->lastFiveMinutes = $lastFiveMinutes;
-        $this->lastFifteenMinutes = $lastFifteenMinutes;
+        return Maybe::just(new self($lastMinute, $lastFiveMinutes, $lastFifteenMinutes));
     }
 
     public function lastMinute(): float

--- a/src/Server/Memory.php
+++ b/src/Server/Memory.php
@@ -10,24 +10,23 @@ use Innmind\Server\Status\Server\Memory\Bytes;
  */
 final class Memory
 {
-    private Bytes $total;
-    private Bytes $active;
-    private Bytes $free;
-    private Bytes $swap;
-    private Bytes $used;
+    private function __construct(
+        private Bytes $total,
+        private Bytes $active,
+        private Bytes $free,
+        private Bytes $swap,
+        private Bytes $used,
+    ) {
+    }
 
-    public function __construct(
+    public static function of(
         Bytes $total,
         Bytes $active,
         Bytes $free,
         Bytes $swap,
         Bytes $used,
-    ) {
-        $this->total = $total;
-        $this->active = $active;
-        $this->free = $free;
-        $this->swap = $swap;
-        $this->used = $used;
+    ): self {
+        return new self($total, $active, $free, $swap, $used);
     }
 
     public function total(): Bytes

--- a/src/Server/Memory.php
+++ b/src/Server/Memory.php
@@ -19,6 +19,9 @@ final class Memory
     ) {
     }
 
+    /**
+     * @psalm-pure
+     */
     public static function of(
         Bytes $total,
         Bytes $active,

--- a/src/Server/Memory/Bytes.php
+++ b/src/Server/Memory/Bytes.php
@@ -30,6 +30,8 @@ final class Bytes
     }
 
     /**
+     * @psalm-pure
+     *
      * @param int<0, max> $value
      */
     public static function of(int $value): self
@@ -73,6 +75,8 @@ final class Bytes
     }
 
     /**
+     * @psalm-pure
+     *
      * @return Maybe<self>
      */
     public static function maybe(string $bytes): Maybe
@@ -96,6 +100,8 @@ final class Bytes
     }
 
     /**
+     * @psalm-pure
+     *
      * @return Maybe<self>
      */
     private static function attemptDarwin(Str $bytes): Maybe
@@ -107,6 +113,8 @@ final class Bytes
     }
 
     /**
+     * @psalm-pure
+     *
      * @return Maybe<self>
      */
     private static function attemptLinux(Str $bytes): Maybe
@@ -118,6 +126,8 @@ final class Bytes
     }
 
     /**
+     * @psalm-pure
+     *
      * @return Maybe<self>
      */
     private static function fromUnit(Str $bytes, Str $unit): Maybe

--- a/src/Server/Memory/Bytes.php
+++ b/src/Server/Memory/Bytes.php
@@ -22,7 +22,6 @@ final class Bytes
     private const PETABYTES = 1024 ** 6;
 
     private int $value;
-    private string $string;
 
     /**
      * @throws BytesCannotBeNegative
@@ -34,48 +33,6 @@ final class Bytes
         }
 
         $this->value = $value;
-        $this->string = $value.'B';
-
-        switch (true) {
-            case $value < self::BYTES:
-                $this->string = $value.'B';
-                break;
-
-            case $value < self::KILOBYTES:
-                $this->string = \sprintf(
-                    '%sKB',
-                    \round($value/self::BYTES, 3),
-                );
-                break;
-
-            case $value < self::MEGABYTES:
-                $this->string = \sprintf(
-                    '%sMB',
-                    \round($value/self::KILOBYTES, 3),
-                );
-                break;
-
-            case $value < self::GIGABYTES:
-                $this->string = \sprintf(
-                    '%sGB',
-                    \round($value/self::MEGABYTES, 3),
-                );
-                break;
-
-            case $value < self::TERABYTES:
-                $this->string = \sprintf(
-                    '%sTB',
-                    \round($value/self::GIGABYTES, 3),
-                );
-                break;
-
-            case $value < self::PETABYTES:
-                $this->string = \sprintf(
-                    '%sPB',
-                    \round($value/self::TERABYTES, 3),
-                );
-                break;
-        }
     }
 
     public function toInt(): int
@@ -85,7 +42,29 @@ final class Bytes
 
     public function toString(): string
     {
-        return $this->string;
+        return match (true) {
+            $this->value < self::BYTES => $this->value.'B',
+            $this->value < self::KILOBYTES => \sprintf(
+                '%sKB',
+                \round($this->value/self::BYTES, 3),
+            ),
+            $this->value < self::MEGABYTES => \sprintf(
+                '%sMB',
+                \round($this->value/self::KILOBYTES, 3),
+            ),
+            $this->value < self::GIGABYTES => \sprintf(
+                '%sGB',
+                \round($this->value/self::MEGABYTES, 3),
+            ),
+            $this->value < self::TERABYTES => \sprintf(
+                '%sTB',
+                \round($this->value/self::GIGABYTES, 3),
+            ),
+            $this->value < self::PETABYTES => \sprintf(
+                '%sPB',
+                \round($this->value/self::TERABYTES, 3),
+            ),
+        };
     }
 
     /**

--- a/src/Server/Process.php
+++ b/src/Server/Process.php
@@ -32,6 +32,8 @@ final class Process
     }
 
     /**
+     * @psalm-pure
+     *
      * @param Maybe<PointInTime> $start
      */
     public static function of(

--- a/src/Server/Process.php
+++ b/src/Server/Process.php
@@ -18,31 +18,31 @@ use Innmind\Immutable\Maybe;
  */
 final class Process
 {
-    private Pid $pid;
-    private User $user;
-    private Percentage $cpu;
-    private Memory $memory;
-    /** @var Maybe<PointInTime> */
-    private Maybe $start;
-    private Command $command;
+    /**
+     * @param Maybe<PointInTime> $start
+     */
+    private function __construct(
+        private Pid $pid,
+        private User $user,
+        private Percentage $cpu,
+        private Memory $memory,
+        private Maybe $start,
+        private Command $command,
+    ) {
+    }
 
     /**
      * @param Maybe<PointInTime> $start
      */
-    public function __construct(
+    public static function of(
         Pid $pid,
         User $user,
         Percentage $cpu,
         Memory $memory,
         Maybe $start,
         Command $command,
-    ) {
-        $this->pid = $pid;
-        $this->user = $user;
-        $this->cpu = $cpu;
-        $this->memory = $memory;
-        $this->start = $start;
-        $this->command = $command;
+    ): self {
+        return new self($pid, $user, $cpu, $memory, $start, $command);
     }
 
     public function pid(): Pid

--- a/src/Server/Process/Command.php
+++ b/src/Server/Process/Command.php
@@ -3,7 +3,6 @@ declare(strict_types = 1);
 
 namespace Innmind\Server\Status\Server\Process;
 
-use Innmind\Server\Status\Exception\EmptyCommandNotAllowed;
 use Innmind\Immutable\{
     RegExp,
     Str,
@@ -14,18 +13,20 @@ use Innmind\Immutable\{
  */
 final class Command
 {
-    private string $value;
+    /**
+     * @param non-empty-string $value
+     */
+    private function __construct(
+        private string $value,
+    ) {
+    }
 
     /**
-     * @throws EmptyCommandNotAllowed
+     * @param non-empty-string $value
      */
-    public function __construct(string $value)
+    public static function of(string $value): self
     {
-        if ($value === '') {
-            throw new EmptyCommandNotAllowed;
-        }
-
-        $this->value = $value;
+        return new self($value);
     }
 
     public function matches(RegExp $pattern): bool
@@ -33,6 +34,9 @@ final class Command
         return $pattern->matches(Str::of($this->value));
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function toString(): string
     {
         return $this->value;

--- a/src/Server/Process/Command.php
+++ b/src/Server/Process/Command.php
@@ -22,6 +22,8 @@ final class Command
     }
 
     /**
+     * @psalm-pure
+     *
      * @param non-empty-string $value
      */
     public static function of(string $value): self

--- a/src/Server/Process/Memory.php
+++ b/src/Server/Process/Memory.php
@@ -16,6 +16,8 @@ final class Memory
     }
 
     /**
+     * @psalm-pure
+     *
      * @return Maybe<self>
      */
     public static function maybe(float $value): Maybe

--- a/src/Server/Process/Memory.php
+++ b/src/Server/Process/Memory.php
@@ -3,25 +3,29 @@ declare(strict_types = 1);
 
 namespace Innmind\Server\Status\Server\Process;
 
-use Innmind\Server\Status\Exception\OutOfBoundsPercentage;
+use Innmind\Immutable\Maybe;
 
 /**
  * @psalm-immutable
  */
 final class Memory
 {
-    private float $value;
+    private function __construct(
+        private float $value,
+    ) {
+    }
 
     /**
-     * @throws OutOfBoundsPercentage
+     * @return Maybe<self>
      */
-    public function __construct(float $value)
+    public static function maybe(float $value): Maybe
     {
         if ($value < 0 || $value > 100) {
-            throw new OutOfBoundsPercentage((string) $value);
+            /** @var Maybe<self> */
+            return Maybe::nothing();
         }
 
-        $this->value = $value;
+        return Maybe::just(new self($value));
     }
 
     public function toFloat(): float

--- a/src/Server/Process/Pid.php
+++ b/src/Server/Process/Pid.php
@@ -36,6 +36,9 @@ final class Pid
         return $this->value === $value;
     }
 
+    /**
+     * @return int<1, max>
+     */
     public function toInt(): int
     {
         return $this->value;

--- a/src/Server/Process/Pid.php
+++ b/src/Server/Process/Pid.php
@@ -3,25 +3,25 @@ declare(strict_types = 1);
 
 namespace Innmind\Server\Status\Server\Process;
 
-use Innmind\Server\Status\Exception\LowestPidPossibleIsOne;
-
 /**
  * @psalm-immutable
  */
 final class Pid
 {
-    private int $value;
+    /**
+     * @param int<1, max> $value
+     */
+    private function __construct(
+        private int $value,
+    ) {
+    }
 
     /**
-     * @throws LowestPidPossibleIsOne
+     * @param int<1, max> $value
      */
-    public function __construct(int $value)
+    public static function of(int $value): self
     {
-        if ($value < 1) {
-            throw new LowestPidPossibleIsOne((string) $value);
-        }
-
-        $this->value = $value;
+        return new self($value);
     }
 
     public function equals(self $pid): bool

--- a/src/Server/Process/Pid.php
+++ b/src/Server/Process/Pid.php
@@ -17,6 +17,8 @@ final class Pid
     }
 
     /**
+     * @psalm-pure
+     *
      * @param int<1, max> $value
      */
     public static function of(int $value): self

--- a/src/Server/Process/User.php
+++ b/src/Server/Process/User.php
@@ -3,27 +3,30 @@ declare(strict_types = 1);
 
 namespace Innmind\Server\Status\Server\Process;
 
-use Innmind\Server\Status\Exception\EmptyUserNotAllowed;
-
 /**
  * @psalm-immutable
  */
 final class User
 {
-    private string $value;
-
     /**
-     * @throws EmptyUserNotAllowed
+     * @param non-empty-string $value
      */
-    public function __construct(string $value)
-    {
-        if ($value === '') {
-            throw new EmptyUserNotAllowed;
-        }
-
-        $this->value = $value;
+    private function __construct(
+        private string $value,
+    ) {
     }
 
+    /**
+     * @param non-empty-string $value
+     */
+    public static function of(string $value): self
+    {
+        return new self($value);
+    }
+
+    /**
+     * @return non-empty-string
+     */
     public function toString(): string
     {
         return $this->value;

--- a/src/Server/Process/User.php
+++ b/src/Server/Process/User.php
@@ -17,6 +17,8 @@ final class User
     }
 
     /**
+     * @psalm-pure
+     *
      * @param non-empty-string $value
      */
     public static function of(string $value): self

--- a/src/Server/Processes/UnixProcesses.php
+++ b/src/Server/Processes/UnixProcesses.php
@@ -134,7 +134,7 @@ final class UnixProcesses implements Processes
                 ->map(Command::of(...));
 
             return Maybe::all($user, $pid, $percentage, $memory, $command)
-                ->map(fn(User $user, Pid $pid, Percentage $percentage, Memory $memory, Command $command) => new Process(
+                ->map(fn(User $user, Pid $pid, Percentage $percentage, Memory $memory, Command $command) => Process::of(
                     $pid,
                     $user,
                     $percentage,

--- a/src/Server/Processes/UnixProcesses.php
+++ b/src/Server/Processes/UnixProcesses.php
@@ -111,7 +111,10 @@ final class UnixProcesses implements Processes
             $parts = $parts
                 ->drop(5)
                 ->map(static fn($part) => $part->toString());
-            $user = $parts->get(0);
+            $user = $parts
+                ->get(0)
+                ->keep(Is::string()->nonEmpty()->asPredicate())
+                ->map(User::of(...));
             $pid = $parts
                 ->get(1)
                 ->map(static fn($value) => (int) $value)
@@ -131,9 +134,9 @@ final class UnixProcesses implements Processes
                 ->map(Command::of(...));
 
             return Maybe::all($user, $pid, $percentage, $memory, $command)
-                ->map(fn(string $user, Pid $pid, Percentage $percentage, Memory $memory, Command $command) => new Process(
+                ->map(fn(User $user, Pid $pid, Percentage $percentage, Memory $memory, Command $command) => new Process(
                     $pid,
-                    new User($user),
+                    $user,
                     $percentage,
                     $memory,
                     $this->clock->at($start, Format::of('D M j H:i:s Y')),

--- a/src/Server/Processes/UnixProcesses.php
+++ b/src/Server/Processes/UnixProcesses.php
@@ -112,7 +112,11 @@ final class UnixProcesses implements Processes
                 ->drop(5)
                 ->map(static fn($part) => $part->toString());
             $user = $parts->get(0);
-            $pid = $parts->get(1);
+            $pid = $parts
+                ->get(1)
+                ->map(static fn($value) => (int) $value)
+                ->keep(Is::int()->positive()->asPredicate())
+                ->map(Pid::of(...));
             $percentage = $parts
                 ->get(2)
                 ->map(static fn($value) => (float) $value)
@@ -127,8 +131,8 @@ final class UnixProcesses implements Processes
                 ->map(Command::of(...));
 
             return Maybe::all($user, $pid, $percentage, $memory, $command)
-                ->map(fn(string $user, string $pid, Percentage $percentage, Memory $memory, Command $command) => new Process(
-                    new Pid((int) $pid),
+                ->map(fn(string $user, Pid $pid, Percentage $percentage, Memory $memory, Command $command) => new Process(
+                    $pid,
                     new User($user),
                     $percentage,
                     $memory,

--- a/src/Server/Processes/UnixProcesses.php
+++ b/src/Server/Processes/UnixProcesses.php
@@ -117,18 +117,21 @@ final class UnixProcesses implements Processes
                 ->get(2)
                 ->map(static fn($value) => (float) $value)
                 ->flatMap(Percentage::maybe(...));
-            $memory = $parts->get(3);
+            $memory = $parts
+                ->get(3)
+                ->map(static fn($value) => (float) $value)
+                ->flatMap(Memory::maybe(...));
             $command = $parts
                 ->get(4)
                 ->keep(Is::string()->nonEmpty()->asPredicate())
                 ->map(Command::of(...));
 
             return Maybe::all($user, $pid, $percentage, $memory, $command)
-                ->map(fn(string $user, string $pid, Percentage $percentage, string $memory, Command $command) => new Process(
+                ->map(fn(string $user, string $pid, Percentage $percentage, Memory $memory, Command $command) => new Process(
                     new Pid((int) $pid),
                     new User($user),
                     $percentage,
-                    new Memory((float) $memory),
+                    $memory,
                     $this->clock->at($start, Format::of('D M j H:i:s Y')),
                     $command,
                 ));

--- a/src/Server/Processes/UnixProcesses.php
+++ b/src/Server/Processes/UnixProcesses.php
@@ -112,15 +112,18 @@ final class UnixProcesses implements Processes
                 ->map(static fn($part) => $part->toString());
             $user = $parts->get(0);
             $pid = $parts->get(1);
-            $percentage = $parts->get(2);
+            $percentage = $parts
+                ->get(2)
+                ->map(static fn($value) => (float) $value)
+                ->flatMap(Percentage::maybe(...));
             $memory = $parts->get(3);
             $command = $parts->get(4);
 
             return Maybe::all($user, $pid, $percentage, $memory, $command)
-                ->map(fn(string $user, string $pid, string $percentage, string $memory, string $command) => new Process(
+                ->map(fn(string $user, string $pid, Percentage $percentage, string $memory, string $command) => new Process(
                     new Pid((int) $pid),
                     new User($user),
-                    new Percentage((float) $percentage),
+                    $percentage,
                     new Memory((float) $memory),
                     $this->clock->at($start, Format::of('D M j H:i:s Y')),
                     new Command($command),

--- a/src/Servers/Linux.php
+++ b/src/Servers/Linux.php
@@ -6,7 +6,6 @@ namespace Innmind\Server\Status\Servers;
 use Innmind\Server\Status\{
     Server,
     Server\Processes,
-    Server\LoadAverage,
     Facade\Cpu\LinuxFacade as CpuFacade,
     Facade\Memory\LinuxFacade as MemoryFacade,
     Facade\LoadAverage\PhpFacade as LoadAverageFacade,
@@ -55,7 +54,7 @@ final class Linux implements Server
     }
 
     #[\Override]
-    public function loadAverage(): LoadAverage
+    public function loadAverage(): Attempt
     {
         return ($this->loadAverage)();
     }

--- a/src/Servers/Logger.php
+++ b/src/Servers/Logger.php
@@ -6,7 +6,6 @@ namespace Innmind\Server\Status\Servers;
 use Innmind\Server\Status\{
     Server,
     Server\Processes,
-    Server\LoadAverage,
     Server\Disk,
 };
 use Innmind\Url\Path;
@@ -66,16 +65,17 @@ final class Logger implements Server
     }
 
     #[\Override]
-    public function loadAverage(): LoadAverage
+    public function loadAverage(): Attempt
     {
-        $loadAverage = $this->server->loadAverage();
-        $this->logger->debug('Load average: {one} {five} {fifteen}', [
-            'one' => $loadAverage->lastMinute(),
-            'five' => $loadAverage->lastFiveMinutes(),
-            'fifteen' => $loadAverage->lastFifteenMinutes(),
-        ]);
+        return $this->server->loadAverage()->map(function($loadAverage) {
+            $this->logger->debug('Load average: {one} {five} {fifteen}', [
+                'one' => $loadAverage->lastMinute(),
+                'five' => $loadAverage->lastFiveMinutes(),
+                'fifteen' => $loadAverage->lastFifteenMinutes(),
+            ]);
 
-        return $loadAverage;
+            return $loadAverage;
+        });
     }
 
     #[\Override]

--- a/src/Servers/OSX.php
+++ b/src/Servers/OSX.php
@@ -6,7 +6,6 @@ namespace Innmind\Server\Status\Servers;
 use Innmind\Server\Status\{
     Server,
     Server\Processes,
-    Server\LoadAverage,
     Facade\Cpu\OSXFacade as CpuFacade,
     Facade\Memory\OSXFacade as MemoryFacade,
     Facade\LoadAverage\PhpFacade as LoadAverageFacade,
@@ -56,7 +55,7 @@ final class OSX implements Server
     }
 
     #[\Override]
-    public function loadAverage(): LoadAverage
+    public function loadAverage(): Attempt
     {
         return ($this->loadAverage)();
     }

--- a/tests/Facade/LoadAverage/PhpFacadeTest.php
+++ b/tests/Facade/LoadAverage/PhpFacadeTest.php
@@ -15,6 +15,6 @@ class PhpFacadeTest extends TestCase
     {
         $facade = new PhpFacade;
 
-        $this->assertInstanceOf(LoadAverage::class, $facade());
+        $this->assertInstanceOf(LoadAverage::class, $facade()->unwrap());
     }
 }

--- a/tests/Facade/Memory/LinuxFacadeTest.php
+++ b/tests/Facade/Memory/LinuxFacadeTest.php
@@ -36,10 +36,7 @@ class LinuxFacadeTest extends TestCase
 
         $facade = new LinuxFacade($this->server->processes());
 
-        $this->assertInstanceOf(Memory::class, $facade()->match(
-            static fn($memory) => $memory,
-            static fn() => null,
-        ));
+        $this->assertInstanceOf(Memory::class, $facade()->unwrap());
     }
 
     public function testReturnNohingWhenInfoNotAccessible()

--- a/tests/Server/Cpu/CoresTest.php
+++ b/tests/Server/Cpu/CoresTest.php
@@ -3,26 +3,16 @@ declare(strict_types = 1);
 
 namespace Tests\Innmind\Server\Status\Server\Cpu;
 
-use Innmind\Server\Status\{
-    Server\Cpu\Cores,
-    Exception\DomainException,
-};
+use Innmind\Server\Status\Server\Cpu\Cores;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
 
 class CoresTest extends TestCase
 {
     public function testInterface()
     {
-        $cores = new Cores(8);
+        $cores = Cores::of(8);
 
         $this->assertSame(8, $cores->toInt());
         $this->assertSame('8', $cores->toString());
-    }
-
-    public function testThrowWhenCoresLowerThanOne()
-    {
-        $this->expectException(DomainException::class);
-
-        new Cores(0);
     }
 }

--- a/tests/Server/Cpu/PercentageTest.php
+++ b/tests/Server/Cpu/PercentageTest.php
@@ -3,26 +3,28 @@ declare(strict_types = 1);
 
 namespace Tests\Innmind\Server\Status\Server\Cpu;
 
-use Innmind\Server\Status\{
-    Server\Cpu\Percentage,
-    Exception\OutOfBoundsPercentage,
-};
+use Innmind\Server\Status\Server\Cpu\Percentage;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
 
 class PercentageTest extends TestCase
 {
     public function testInterface()
     {
-        $percentage = new Percentage(42.24);
+        $percentage = Percentage::maybe(42.24)->match(
+            static fn($percentage) => $percentage,
+            static fn() => null,
+        );
 
+        $this->assertNotNull($percentage);
         $this->assertSame(42.24, $percentage->toFloat());
         $this->assertSame('42.24%', $percentage->toString());
     }
 
-    public function testThrowWhenPercentageLowerThanZero()
+    public function testReturnNothingWhenPercentageLowerThanZero()
     {
-        $this->expectException(OutOfBoundsPercentage::class);
-
-        new Percentage(-1);
+        $this->assertNull(Percentage::maybe(-1)->match(
+            static fn($percentage) => $percentage,
+            static fn() => null,
+        ));
     }
 }

--- a/tests/Server/CpuTest.php
+++ b/tests/Server/CpuTest.php
@@ -15,9 +15,18 @@ class CpuTest extends TestCase
     public function testInterface()
     {
         $cpu = new Cpu(
-            $user = new Percentage(31),
-            $system = new Percentage(33),
-            $idle = new Percentage(36),
+            $user = Percentage::maybe(31)->match(
+                static fn($percentage) => $percentage,
+                static fn() => throw new \Exception('Should be valid'),
+            ),
+            $system = Percentage::maybe(33)->match(
+                static fn($percentage) => $percentage,
+                static fn() => throw new \Exception('Should be valid'),
+            ),
+            $idle = Percentage::maybe(36)->match(
+                static fn($percentage) => $percentage,
+                static fn() => throw new \Exception('Should be valid'),
+            ),
             $cores = Cores::of(4),
         );
 

--- a/tests/Server/CpuTest.php
+++ b/tests/Server/CpuTest.php
@@ -14,7 +14,7 @@ class CpuTest extends TestCase
 {
     public function testInterface()
     {
-        $cpu = new Cpu(
+        $cpu = Cpu::of(
             $user = Percentage::maybe(31)->match(
                 static fn($percentage) => $percentage,
                 static fn() => throw new \Exception('Should be valid'),

--- a/tests/Server/CpuTest.php
+++ b/tests/Server/CpuTest.php
@@ -18,7 +18,7 @@ class CpuTest extends TestCase
             $user = new Percentage(31),
             $system = new Percentage(33),
             $idle = new Percentage(36),
-            $cores = new Cores(4),
+            $cores = Cores::of(4),
         );
 
         $this->assertSame($user, $cpu->user());

--- a/tests/Server/Disk/LoggerDiskTest.php
+++ b/tests/Server/Disk/LoggerDiskTest.php
@@ -40,7 +40,7 @@ class LoggerDiskTest extends TestCase
     {
         $disk = new LoggerDisk($this->disk(), new NullLogger);
 
-        $this->assertInstanceOf(Volume::class, $disk->get(new MountPoint('/'))->match(
+        $this->assertInstanceOf(Volume::class, $disk->get(MountPoint::of('/'))->match(
             static fn($volume) => $volume,
             static fn() => null,
         ));

--- a/tests/Server/Disk/UnixDiskTest.php
+++ b/tests/Server/Disk/UnixDiskTest.php
@@ -56,7 +56,7 @@ class UnixDiskTest extends TestCase
     {
         $volume = $this
             ->disk
-            ->get(new MountPoint('/'))
+            ->get(MountPoint::of('/'))
             ->match(
                 static fn($volume) => $volume,
                 static fn() => null,

--- a/tests/Server/Disk/Volume/MountPointTest.php
+++ b/tests/Server/Disk/Volume/MountPointTest.php
@@ -3,25 +3,15 @@ declare(strict_types = 1);
 
 namespace Tests\Innmind\Server\Status\Server\Disk\Volume;
 
-use Innmind\Server\Status\{
-    Server\Disk\Volume\MountPoint,
-    Exception\EmptyPathNotAllowed,
-};
+use Innmind\Server\Status\Server\Disk\Volume\MountPoint;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
 
 class MountPointTest extends TestCase
 {
     public function testInterface()
     {
-        $mountPoint = new MountPoint('foo');
+        $mountPoint = MountPoint::of('foo');
 
         $this->assertSame('foo', $mountPoint->toString());
-    }
-
-    public function testThrowWhenEmptyMountPoint()
-    {
-        $this->expectException(EmptyPathNotAllowed::class);
-
-        new MountPoint('');
     }
 }

--- a/tests/Server/Disk/Volume/UsageTest.php
+++ b/tests/Server/Disk/Volume/UsageTest.php
@@ -3,33 +3,36 @@ declare(strict_types = 1);
 
 namespace Tests\Innmind\Server\Status\Server\Disk\Volume;
 
-use Innmind\Server\Status\{
-    Server\Disk\Volume\Usage,
-    Exception\OutOfBoundsPercentage,
-};
+use Innmind\Server\Status\Server\Disk\Volume\Usage;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
 
 class UsageTest extends TestCase
 {
     public function testInterface()
     {
-        $usage = new Usage(42.24);
+        $usage = Usage::maybe(42.24)->match(
+            static fn($usage) => $usage,
+            static fn() => null,
+        );
 
+        $this->assertNotNull($usage);
         $this->assertSame(42.24, $usage->toFloat());
         $this->assertSame('42.24%', $usage->toString());
     }
 
-    public function testThrowWhenUsageLowerThanZero()
+    public function testReturnNothingWhenUsageLowerThanZero()
     {
-        $this->expectException(OutOfBoundsPercentage::class);
-
-        new Usage(-1);
+        $this->assertNull(Usage::maybe(-1)->match(
+            static fn($usage) => $usage,
+            static fn() => null,
+        ));
     }
 
-    public function testThrowWhenUsageHigherThanHundred()
+    public function testReturnNothingWhenUsageHigherThanHundred()
     {
-        $this->expectException(OutOfBoundsPercentage::class);
-
-        new Usage(101);
+        $this->assertNull(Usage::maybe(101)->match(
+            static fn($usage) => $usage,
+            static fn() => null,
+        ));
     }
 }

--- a/tests/Server/Disk/VolumeTest.php
+++ b/tests/Server/Disk/VolumeTest.php
@@ -20,7 +20,10 @@ class VolumeTest extends TestCase
             $size = new Bytes(42),
             $available = new Bytes(42),
             $used = new Bytes(42),
-            $usage = new Usage(100),
+            $usage = Usage::maybe(100)->match(
+                static fn($usage) => $usage,
+                static fn() => throw new \Exception('Should be valid'),
+            ),
         );
 
         $this->assertSame($mount, $volume->mountPoint());

--- a/tests/Server/Disk/VolumeTest.php
+++ b/tests/Server/Disk/VolumeTest.php
@@ -16,7 +16,7 @@ class VolumeTest extends TestCase
     public function testInterface()
     {
         $volume = new Volume(
-            $mount = new MountPoint('/'),
+            $mount = MountPoint::of('/'),
             $size = new Bytes(42),
             $available = new Bytes(42),
             $used = new Bytes(42),

--- a/tests/Server/Disk/VolumeTest.php
+++ b/tests/Server/Disk/VolumeTest.php
@@ -17,9 +17,9 @@ class VolumeTest extends TestCase
     {
         $volume = Volume::of(
             $mount = MountPoint::of('/'),
-            $size = new Bytes(42),
-            $available = new Bytes(42),
-            $used = new Bytes(42),
+            $size = Bytes::of(42),
+            $available = Bytes::of(42),
+            $used = Bytes::of(42),
             $usage = Usage::maybe(100)->match(
                 static fn($usage) => $usage,
                 static fn() => throw new \Exception('Should be valid'),

--- a/tests/Server/Disk/VolumeTest.php
+++ b/tests/Server/Disk/VolumeTest.php
@@ -15,7 +15,7 @@ class VolumeTest extends TestCase
 {
     public function testInterface()
     {
-        $volume = new Volume(
+        $volume = Volume::of(
             $mount = MountPoint::of('/'),
             $size = new Bytes(42),
             $available = new Bytes(42),

--- a/tests/Server/LoadAverageTest.php
+++ b/tests/Server/LoadAverageTest.php
@@ -3,41 +3,45 @@ declare(strict_types = 1);
 
 namespace Tests\Innmind\Server\Status\Server;
 
-use Innmind\Server\Status\{
-    Server\LoadAverage,
-    Exception\LoadAverageCannotBeNegative,
-};
+use Innmind\Server\Status\Server\LoadAverage;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
 
 class LoadAverageTest extends TestCase
 {
     public function testInterface()
     {
-        $load = new LoadAverage(1, 5, 15);
+        $load = LoadAverage::maybe(1, 5, 15)->match(
+            static fn($load) => $load,
+            static fn() => null,
+        );
 
+        $this->assertNotNull($load);
         $this->assertSame(1.0, $load->lastMinute());
         $this->assertSame(5.0, $load->lastFiveMinutes());
         $this->assertSame(15.0, $load->lastFifteenMinutes());
     }
 
-    public function testThrowWhenNegativeLastMinuteLoad()
+    public function testReturnNothingWhenNegativeLastMinuteLoad()
     {
-        $this->expectException(LoadAverageCannotBeNegative::class);
-
-        new LoadAverage(-1, 5, 15);
+        $this->assertNull(LoadAverage::maybe(-1, 5, 15)->match(
+            static fn($load) => $load,
+            static fn() => null,
+        ));
     }
 
-    public function testThrowWhenNegativeLastFiveMinuteLoad()
+    public function testReturnNothingWhenNegativeLastFiveMinuteLoad()
     {
-        $this->expectException(LoadAverageCannotBeNegative::class);
-
-        new LoadAverage(1, -5, 15);
+        $this->assertNull(LoadAverage::maybe(1, -5, 15)->match(
+            static fn($load) => $load,
+            static fn() => null,
+        ));
     }
 
-    public function testThrowWhenNegativeLastFifteenMinuteLoad()
+    public function testReturnNothingWhenNegativeLastFifteenMinuteLoad()
     {
-        $this->expectException(LoadAverageCannotBeNegative::class);
-
-        new LoadAverage(1, 5, -15);
+        $this->assertNull(LoadAverage::maybe(1, 5, -15)->match(
+            static fn($load) => $load,
+            static fn() => null,
+        ));
     }
 }

--- a/tests/Server/Memory/BytesTest.php
+++ b/tests/Server/Memory/BytesTest.php
@@ -3,10 +3,7 @@ declare(strict_types = 1);
 
 namespace Tests\Innmind\Server\Status\Server\Memory;
 
-use Innmind\Server\Status\{
-    Server\Memory\Bytes,
-    Exception\BytesCannotBeNegative,
-};
+use Innmind\Server\Status\Server\Memory\Bytes;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -15,23 +12,16 @@ class BytesTest extends TestCase
     #[DataProvider('steps')]
     public function testInterface($value, $expected)
     {
-        $bytes = new Bytes($value);
+        $bytes = Bytes::of($value);
 
         $this->assertSame($value, $bytes->toInt());
         $this->assertSame($expected, $bytes->toString());
     }
 
-    public function testThrowWhenNegative()
-    {
-        $this->expectException(BytesCannotBeNegative::class);
-
-        new Bytes(-1);
-    }
-
     #[DataProvider('strings')]
     public function testFromString($string, $expected)
     {
-        $bytes = Bytes::of($string)->match(
+        $bytes = Bytes::maybe($string)->match(
             static fn($bytes) => $bytes,
             static fn() => null,
         );
@@ -42,7 +32,7 @@ class BytesTest extends TestCase
 
     public function testReturnNothingWhenUnknownFormat()
     {
-        $this->assertNull(Bytes::of('42Br')->match(
+        $this->assertNull(Bytes::maybe('42Br')->match(
             static fn($bytes) => $bytes,
             static fn() => null,
         ));
@@ -51,7 +41,7 @@ class BytesTest extends TestCase
     #[DataProvider('invalidStrings')]
     public function testReturnNothingWhenStringTooShort($string)
     {
-        $this->assertNull(Bytes::of($string)->match(
+        $this->assertNull(Bytes::maybe($string)->match(
             static fn($bytes) => $bytes,
             static fn() => null,
         ));

--- a/tests/Server/MemoryTest.php
+++ b/tests/Server/MemoryTest.php
@@ -13,7 +13,7 @@ class MemoryTest extends TestCase
 {
     public function testInterface()
     {
-        $memory = new Memory(
+        $memory = Memory::of(
             $total = Bytes::of(42),
             $active = Bytes::of(42),
             $free = Bytes::of(42),

--- a/tests/Server/MemoryTest.php
+++ b/tests/Server/MemoryTest.php
@@ -14,11 +14,11 @@ class MemoryTest extends TestCase
     public function testInterface()
     {
         $memory = new Memory(
-            $total = new Bytes(42),
-            $active = new Bytes(42),
-            $free = new Bytes(42),
-            $swap = new Bytes(42),
-            $used = new Bytes(42),
+            $total = Bytes::of(42),
+            $active = Bytes::of(42),
+            $free = Bytes::of(42),
+            $swap = Bytes::of(42),
+            $used = Bytes::of(42),
         );
 
         $this->assertSame($total, $memory->total());

--- a/tests/Server/Process/CommandTest.php
+++ b/tests/Server/Process/CommandTest.php
@@ -3,10 +3,7 @@ declare(strict_types = 1);
 
 namespace Tests\Innmind\Server\Status\Server\Process;
 
-use Innmind\Server\Status\{
-    Server\Process\Command,
-    Exception\EmptyCommandNotAllowed,
-};
+use Innmind\Server\Status\Server\Process\Command;
 use Innmind\Immutable\RegExp;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
 
@@ -14,23 +11,16 @@ class CommandTest extends TestCase
 {
     public function testInterface()
     {
-        $command = new Command('foo');
+        $command = Command::of('foo');
 
         $this->assertSame('foo', $command->toString());
     }
 
     public function testMatches()
     {
-        $command = new Command('foo');
+        $command = Command::of('foo');
 
         $this->assertTrue($command->matches(RegExp::of('/^foo/')));
         $this->assertFalse($command->matches(RegExp::of('/bar/')));
-    }
-
-    public function testThrowWhenEmptyCommand()
-    {
-        $this->expectException(EmptyCommandNotAllowed::class);
-
-        new Command('');
     }
 }

--- a/tests/Server/Process/MemoryTest.php
+++ b/tests/Server/Process/MemoryTest.php
@@ -3,33 +3,36 @@ declare(strict_types = 1);
 
 namespace Tests\Innmind\Server\Status\Server\Process;
 
-use Innmind\Server\Status\{
-    Server\Process\Memory,
-    Exception\OutOfBoundsPercentage,
-};
+use Innmind\Server\Status\Server\Process\Memory;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
 
 class MemoryTest extends TestCase
 {
     public function testInterface()
     {
-        $memory = new Memory(42.24);
+        $memory = Memory::maybe(42.24)->match(
+            static fn($memory) => $memory,
+            static fn() => null,
+        );
 
+        $this->assertNotNull($memory);
         $this->assertSame(42.24, $memory->toFloat());
         $this->assertSame('42.24%', $memory->toString());
     }
 
-    public function testThrowWhenMemoryLowerThanZero()
+    public function testReturnNothingWhenMemoryLowerThanZero()
     {
-        $this->expectException(OutOfBoundsPercentage::class);
-
-        new Memory(-1);
+        $this->assertNull(Memory::maybe(-1)->match(
+            static fn($memory) => $memory,
+            static fn() => null,
+        ));
     }
 
-    public function testThrowWhenMemoryHigherThanHundred()
+    public function testReturnNothingWhenMemoryHigherThanHundred()
     {
-        $this->expectException(OutOfBoundsPercentage::class);
-
-        new Memory(101);
+        $this->assertNull(Memory::maybe(101)->match(
+            static fn($memory) => $memory,
+            static fn() => null,
+        ));
     }
 }

--- a/tests/Server/Process/PidTest.php
+++ b/tests/Server/Process/PidTest.php
@@ -3,26 +3,16 @@ declare(strict_types = 1);
 
 namespace Tests\Innmind\Server\Status\Server\Process;
 
-use Innmind\Server\Status\{
-    Server\Process\Pid,
-    Exception\LowestPidPossibleIsOne,
-};
+use Innmind\Server\Status\Server\Process\Pid;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
 
 class PidTest extends TestCase
 {
     public function testInterface()
     {
-        $pid = new Pid(42);
+        $pid = Pid::of(42);
 
         $this->assertSame(42, $pid->toInt());
         $this->assertSame('42', $pid->toString());
-    }
-
-    public function testThrowWhenPidTooLow()
-    {
-        $this->expectException(LowestPidPossibleIsOne::class);
-
-        new Pid(0);
     }
 }

--- a/tests/Server/Process/UserTest.php
+++ b/tests/Server/Process/UserTest.php
@@ -3,25 +3,15 @@ declare(strict_types = 1);
 
 namespace Tests\Innmind\Server\Status\Server\Process;
 
-use Innmind\Server\Status\{
-    Server\Process\User,
-    Exception\EmptyUserNotAllowed,
-};
+use Innmind\Server\Status\Server\Process\User;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
 
 class UserTest extends TestCase
 {
     public function testInterface()
     {
-        $user = new User('foo');
+        $user = User::of('foo');
 
         $this->assertSame('foo', $user->toString());
-    }
-
-    public function testThrowWhenEmptyUser()
-    {
-        $this->expectException(EmptyUserNotAllowed::class);
-
-        new User('');
     }
 }

--- a/tests/Server/ProcessTest.php
+++ b/tests/Server/ProcessTest.php
@@ -34,7 +34,10 @@ class ProcessTest extends TestCase
                         static fn($percentage) => $percentage,
                         static fn() => throw new \Exception('Should be valid'),
                     ),
-                    $memory = new Memory(42),
+                    $memory = Memory::maybe(42)->match(
+                        static fn($memory) => $memory,
+                        static fn() => throw new \Exception('Should be valid'),
+                    ),
                     $start = Maybe::just($pointInTime),
                     $command = Command::of('/sbin/launchd'),
                 );

--- a/tests/Server/ProcessTest.php
+++ b/tests/Server/ProcessTest.php
@@ -29,7 +29,7 @@ class ProcessTest extends TestCase
             ->then(function($pointInTime) {
                 $process = new Process(
                     $pid = Pid::of(1),
-                    $user = new User('root'),
+                    $user = User::of('root'),
                     $cpu = Percentage::maybe(42)->match(
                         static fn($percentage) => $percentage,
                         static fn() => throw new \Exception('Should be valid'),

--- a/tests/Server/ProcessTest.php
+++ b/tests/Server/ProcessTest.php
@@ -28,7 +28,7 @@ class ProcessTest extends TestCase
             ->forAll(PointInTime::any())
             ->then(function($pointInTime) {
                 $process = new Process(
-                    $pid = new Pid(1),
+                    $pid = Pid::of(1),
                     $user = new User('root'),
                     $cpu = Percentage::maybe(42)->match(
                         static fn($percentage) => $percentage,

--- a/tests/Server/ProcessTest.php
+++ b/tests/Server/ProcessTest.php
@@ -30,7 +30,10 @@ class ProcessTest extends TestCase
                 $process = new Process(
                     $pid = new Pid(1),
                     $user = new User('root'),
-                    $cpu = new Percentage(42),
+                    $cpu = Percentage::maybe(42)->match(
+                        static fn($percentage) => $percentage,
+                        static fn() => throw new \Exception('Should be valid'),
+                    ),
                     $memory = new Memory(42),
                     $start = Maybe::just($pointInTime),
                     $command = new Command('/sbin/launchd'),

--- a/tests/Server/ProcessTest.php
+++ b/tests/Server/ProcessTest.php
@@ -27,7 +27,7 @@ class ProcessTest extends TestCase
         $this
             ->forAll(PointInTime::any())
             ->then(function($pointInTime) {
-                $process = new Process(
+                $process = Process::of(
                     $pid = Pid::of(1),
                     $user = User::of('root'),
                     $cpu = Percentage::maybe(42)->match(

--- a/tests/Server/ProcessTest.php
+++ b/tests/Server/ProcessTest.php
@@ -36,7 +36,7 @@ class ProcessTest extends TestCase
                     ),
                     $memory = new Memory(42),
                     $start = Maybe::just($pointInTime),
-                    $command = new Command('/sbin/launchd'),
+                    $command = Command::of('/sbin/launchd'),
                 );
 
                 $this->assertSame($pid, $process->pid());

--- a/tests/Server/Processes/LoggerProcessesTest.php
+++ b/tests/Server/Processes/LoggerProcessesTest.php
@@ -40,7 +40,7 @@ class LoggerProcessesTest extends TestCase
     {
         $processes = new LoggerProcesses($this->processes(), new NullLogger);
 
-        $this->assertInstanceOf(Process::class, $processes->get(new Pid(1))->match(
+        $this->assertInstanceOf(Process::class, $processes->get(Pid::of(1))->match(
             static fn($process) => $process,
             static fn() => null,
         ));

--- a/tests/Server/Processes/UnixProcessesTest.php
+++ b/tests/Server/Processes/UnixProcessesTest.php
@@ -76,7 +76,7 @@ class UnixProcessesTest extends TestCase
     {
         $process = $this
             ->processes
-            ->get(new Pid(1))
+            ->get(Pid::of(1))
             ->match(
                 static fn($process) => $process,
                 static fn() => null,
@@ -91,7 +91,7 @@ class UnixProcessesTest extends TestCase
         $this->assertNull(
             $this
                 ->processes
-                ->get(new Pid(42424))
+                ->get(Pid::of(42424))
                 ->match(
                     static fn($process) => $process,
                     static fn() => null,

--- a/tests/Servers/LinuxTest.php
+++ b/tests/Servers/LinuxTest.php
@@ -87,7 +87,7 @@ class LinuxTest extends TestCase
 
     public function testLoadAverage()
     {
-        $this->assertInstanceOf(LoadAverage::class, $this->server->loadAverage());
+        $this->assertInstanceOf(LoadAverage::class, $this->server->loadAverage()->unwrap());
     }
 
     public function testDisk()

--- a/tests/Servers/LinuxTest.php
+++ b/tests/Servers/LinuxTest.php
@@ -73,10 +73,7 @@ class LinuxTest extends TestCase
             $this
                 ->server
                 ->memory()
-                ->match(
-                    static fn($memory) => $memory,
-                    static fn() => null,
-                ),
+                ->unwrap(),
         );
     }
 

--- a/tests/Servers/LoggerTest.php
+++ b/tests/Servers/LoggerTest.php
@@ -66,7 +66,7 @@ class LoggerTest extends TestCase
     {
         $server = new Logger($this->server(), new NullLogger);
 
-        $this->assertInstanceOf(LoadAverage::class, $server->loadAverage());
+        $this->assertInstanceOf(LoadAverage::class, $server->loadAverage()->unwrap());
     }
 
     public function testDisk()

--- a/tests/Servers/OSXTest.php
+++ b/tests/Servers/OSXTest.php
@@ -86,7 +86,7 @@ class OSXTest extends TestCase
 
     public function testLoadAverage()
     {
-        $this->assertInstanceOf(LoadAverage::class, $this->server->loadAverage());
+        $this->assertInstanceOf(LoadAverage::class, $this->server->loadAverage()->unwrap());
     }
 
     public function testDisk()


### PR DESCRIPTION
While closing down value objects it appeared `LoadAverage` wasn't safe. The possible error is now expressed as a type by `Server::loadAverage()` now returning an `Attempt`.