### PR TITLE
Remove exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 - `Innmind\Server\Status\Exception\EmptyUserNotAllowed`
 - `Innmind\Server\Status\Exception\LoadAverageCannotBeNegative`
 - `Innmind\Server\Status\Exception\DomainException`
+- `Innmind\Server\Status\Exception\UnsupportedOperatingSystem`
+- `Innmind\Server\Status\Exception\RuntimeException`
+- `Innmind\Server\Status\Exception\Exception`
 
 ## 4.1.1 - 2024-09-30
 

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -1,8 +1,0 @@
-<?php
-declare(strict_types = 1);
-
-namespace Innmind\Server\Status\Exception;
-
-interface Exception extends \Throwable
-{
-}

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,8 +1,0 @@
-<?php
-declare(strict_types = 1);
-
-namespace Innmind\Server\Status\Exception;
-
-class RuntimeException extends \RuntimeException implements Exception
-{
-}

--- a/src/Exception/UnsupportedOperatingSystem.php
+++ b/src/Exception/UnsupportedOperatingSystem.php
@@ -1,8 +1,0 @@
-<?php
-declare(strict_types = 1);
-
-namespace Innmind\Server\Status\Exception;
-
-final class UnsupportedOperatingSystem extends RuntimeException
-{
-}

--- a/src/ServerFactory.php
+++ b/src/ServerFactory.php
@@ -3,32 +3,24 @@ declare(strict_types = 1);
 
 namespace Innmind\Server\Status;
 
-use Innmind\Server\Status\{
-    Servers\OSX,
-    Servers\Linux,
-    Exception\UnsupportedOperatingSystem,
+use Innmind\Server\Status\Servers\{
+    OSX,
+    Linux,
 };
 use Innmind\Server\Control\Server as Control;
 use Innmind\TimeContinuum\Clock;
 
 final class ServerFactory
 {
-    /**
-     * @throws UnsupportedOperatingSystem
-     */
     public static function build(
         Clock $clock,
         Control $control,
         EnvironmentPath $path,
     ): Server {
-        switch (\PHP_OS) {
-            case 'Darwin':
-                return new OSX($clock, $control, $path);
-
-            case 'Linux':
-                return new Linux($clock, $control);
-        }
-
-        throw new UnsupportedOperatingSystem;
+        return match (\PHP_OS) {
+            'Darwin' => new OSX($clock, $control, $path),
+            'Linux' => new Linux($clock, $control),
+            default => throw new \LogicException('Unsupported operating system '.\PHP_OS),
+        };
     }
 }


### PR DESCRIPTION
Since the exception thrown when the OS is not supported is not meant to be caught. There is no need to have a dedicated class for that.